### PR TITLE
Because misfit for Encypedia britannica, domains are also added as Hosts...

### DIFF
--- a/accesRef/traitements/cree_liste_hosts.php
+++ b/accesRef/traitements/cree_liste_hosts.php
@@ -1,34 +1,33 @@
 #!/usr/bin/php
 <?php
 /*
- * V1.3 
- * 
- * Create the ../hosts_domains/liste_hosts file used to rewrite URL with or without 
+ * V1.3
+ *
+ * Create the ../hosts_domains/liste_hosts file used to rewrite URL with or without
  * ezproxy suffix. It needs all your config file to be in ../hosts_domains directory.
- * Every one must have .txt extension to be parsed.   
+ * Every one must have .txt extension to be parsed.
  * V1.0 Append file with host domain conflicts detected
  * V1.1 Same parsing order as ezproxy to affect good index / name SPU to doubled definitions
- * V1.2  create conflits and general files . conflits contains the conflicts between 
- * 	database definition and general reflects the links SPU -> Hosts and Domains.  
- * V1.3 quickness upgrade  
+ * V1.2  create conflits and general files . conflits contains the conflicts between
+ * 	database definition and general reflects the links SPU -> Hosts and Domains.
+ * V1.3 quickness upgrade
+ * V1.4 Because misfit for Encypedia britannica, domains are also added as Host (and SPU hosts)
  *
- * Crée le fichier ../hosts_domains/liste_hosts à partir de vos fichier de configuration 
- * mis dans le même répertoire et dont le nom DOIT se terminer par .txt.  
- * Le fichier liste_hosts est celui utilisé la librairie accesRef.lib.php pour renvoyer 
+ * Crée le fichier ../hosts_domains/liste_hosts à partir de vos fichier de configuration
+ * mis dans le même répertoire et dont le nom DOIT se terminer par .txt.
+ * Le fichier liste_hosts est celui utilisé la librairie accesRef.lib.php pour renvoyer
  * une URL vers le reverse proxy ou non.
  * V1.0 crée le fichier des conflits de définitions multiples notamment entre Host et domaines
  * V1.1 analyse des fichiers identique à celle de ezproxy pour indiquer LE bon SPU avec son
  * 		n° à chaque	conflit trouvé.
  * V1.2 création du fichier des conflits et du fichier general (liste des hosts par SPU)
  * V1.3 accélération traitement
+ * V1.4 suite à expérience avec Encypedia britannica, ajout des domaines pour leur réécriture
  */
 
 $ce_repertoire = dirname(__FILE__);
 include_once ($ce_repertoire."/../conf/conf.inc.php");
-<<<<<<< HEAD
-=======
-$fic_liste.=".test";
->>>>>>> ee89e4d44c2ffe383bb7c5ba0726dd87b67865e9
+//$fic_liste.=".test";
 
 
 
@@ -40,7 +39,7 @@ if (file_exists("$dir_sources/config.txt")) $fic_boot="config.txt";
 elseif (file_exists("$dir_sources/ezproxy.cfg")) $fic_boot="ezproxy.cfg";
 else exit ("Not found / inexistant $dir_sources/ config.txt | ezproxy.cfg");
 $fs = fopen ("$dir_sources/$fic_boot",'r');
-$fpoint=array($fs); 
+$fpoint=array($fs);
 $fichiers=array($fic_boot);
 $ipoint = 0;
 $un_fic=$fic_boot;
@@ -69,13 +68,13 @@ while (($une_ligne=lit_ligne ())!==false){
 	$ss_type = (substr($clause,1,1)=='j')?'J':'';
 
 	$une_ligne = trim(substr($une_ligne,strlen($clause)));
-	
+
 	if ($type =='T') {
 		$titre_cou = $une_ligne;
 		continue;
 	}
 	if ($type =='U') {
-		$no_spu = count($tab_spu); 
+		$no_spu = count($tab_spu);
 		$tab_spu[]  = $une_ligne;
 		$tab_titre[]= $titre_cou;
 		$tab_HD[]   = array();
@@ -83,7 +82,7 @@ while (($une_ligne=lit_ligne ())!==false){
 	}
 	if ($no_spu<0) {
 		fprintf(STDERR, "ERR: Host/Domain before any SPU / avant tout SPU.\n");
-		$no_spu = 0; 
+		$no_spu = 0;
 		$tab_spu[]  = "BF/AV 1. SPU";
 		$tab_titre[]= "No Title / Avant tout SPU.";
 		$tab_HD[]   = array();
@@ -96,13 +95,13 @@ while (($une_ligne=lit_ligne ())!==false){
 	}
 	$une_ligne=$matches[1];
 	$cle = cunu_cle($une_ligne);
-	
+
 	$no_url = count($tab_HD[$no_spu]);
 	$tab_HD[$no_spu][] = $cle;
-	
+
 	if ($type=="D"){
 		if (!isset($tab_domain[$cle]))$tab_domain[$cle]=array();
-		$tab_domain[$cle][]=$no_spu; 
+		$tab_domain[$cle][]=$no_spu;
 	}
 	$enr_ref = array	('no_url'=>$no_url
 						,'no_spu'=>$no_spu
@@ -110,7 +109,7 @@ while (($une_ligne=lit_ligne ())!==false){
 						,'type'=>$type
 						,'ss_type'=>$ss_type
 						);
-	if (!isset ($tab_gen [$cle])) 
+	if (!isset ($tab_gen [$cle]))
 		$tab_gen [$cle]=array('orig'=>$une_ligne,'defs'=>array());
 	$tab_gen[$cle]['defs'][] = $enr_ref;
 }
@@ -123,17 +122,18 @@ foreach ($tab_gen  as $cle=>$struct){
 	$enrs = $struct['defs']; $enr = $enrs[0];
 	$no_spu_cou = $enr['no_spu'];
 	$est_host=($enr['type']=='H' || $enr['type']=='U');
-	$i = 1; 
+	$i = 1;
 	while ($i<count($struct['defs']) ){
 		$enr = $enrs[$i];
 		if ($no_spu_cou != $enr['no_spu']){
 			ajout_conflit ($no_spu_cou,$enr['no_spu'],$lurl);
-		} 
-		$est_host=($enr['type']=='H' || $enr['type']=='U');
+		}
+		if ($enr['type']=='H' || $enr['type']=='U') $est_host=true;
 		$i++;
 	}
+	$tab_hosts[]=$lurl;
 	if ($est_host){
-		$tab_hosts[]=$lurl;
+//		$tab_hosts[]=$lurl;
 		$ipos = 0;
 		while (($ipos=strpos($cle, '|',$ipos))!==false){
 			if (isset($tab_domain[substr($cle,0,$ipos)])){
@@ -201,8 +201,8 @@ function ecrit_enr($cle ,$no_spu_cou){
 		$type=$enr['type'].$enr['ss_type'];
 		if ($no_spu==$no_spu_cou)
 			$milieu .= ", ($un_fic) [$type]";
-		else 
-			$suite .= ", $no_spu ($un_fic) [$type]";	
+		else
+			$suite .= ", $no_spu ($un_fic) [$type]";
 	}
 	$res = $debut." In ".substr($milieu,1);
 	if ($suite) $res.= " ++ ".substr($suite,1);


### PR DESCRIPTION
... (and SPU hosts)

Some domains as britannica.com must be rewritten indead they aren't used in host (SPU host) declaration.
